### PR TITLE
Added Builder to BridgeConfiguration and updated BridgeWorkerFactory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-project/project/
-project/target/
-target/
-test-output/
+.idea
+**/*target/
+

--- a/src/main/scala/com/gilt/calatrava/kinesis/BridgeConfiguration.scala
+++ b/src/main/scala/com/gilt/calatrava/kinesis/BridgeConfiguration.scala
@@ -1,21 +1,59 @@
 package com.gilt.calatrava.kinesis
 
+import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider}
+
 /**
- * Configuration for the Calatrava Bridge that we want to consume
- *
- * @param clientAppName             a name for this application, must be unique for this Bridge
- * @param streamName                the name of the Kinesis stream associated with the Bridge
- * @param bucketName                the name of the S3 bucket where the Bridge stores large events
- * @param kinesisIamRoleArnOpt      the name of an IAM role that this application can assume to get access to AWS Kinesis
- * @param dynamoIamRoleArnOpt       the name of an IAM role that this application can assume to get access to AWS Dynamo
- * @param metricsConfigOpt          optional configuration for CloudWatch metrics factory
- */
+  * Configuration for the Calatrava Bridge that we want to consume
+  *
+  * @param clientAppName              a name for this application, must be unique for this Bridge
+  * @param streamName                 the name of the Kinesis stream associated with the Bridge
+  * @param bucketName                 the name of the S3 bucket where the Bridge stores large events
+  * @param kinesisCredentialsProvider Credentials Provider to get access to AWS Kinesis
+  * @param dynamoCredentialsProvider  Credentials Provider to get access to AWS Dynamo
+  * @param metricsConfigOpt           optional configuration for CloudWatch metrics factory
+  */
 case class BridgeConfiguration(clientAppName: String,
                                streamName: String,
                                bucketName: String,
-                               kinesisIamRoleArnOpt: Option[String],
-                               dynamoIamRoleArnOpt: Option[String],
-                               metricsConfigOpt: Option[MetricsConfiguration])
+                               kinesisCredentialsProvider: AWSCredentialsProvider,
+                               dynamoCredentialsProvider: AWSCredentialsProvider,
+                               metricsConfigOpt: Option[MetricsConfiguration] = None)
+
+case class BridgeConfigurationBuilder(clientAppName: String,
+                                      streamName: String,
+                                      bucketName: String,
+                                      kinesisCredentialsProviderOpt: Option[AWSCredentialsProvider] = None,
+                                      dynamoCredentialsProviderOpt: Option[AWSCredentialsProvider] = None,
+                                      metricsConfigOpt: Option[MetricsConfiguration] = None) {
+
+  def withKinesisCredentialsProvider(kinesisCredentialsProvider: AWSCredentialsProvider) = this.copy(kinesisCredentialsProviderOpt = Some(kinesisCredentialsProvider))
+
+  def withKinesisRoleIamArn(kinesisRoleIamArn: String) = this.copy(kinesisCredentialsProviderOpt = Some(new STSAssumeRoleSessionCredentialsProvider(kinesisRoleIamArn, clientAppName)))
+
+  def withDynamoCredentialsProvider(dynamoCredentialsProvider: AWSCredentialsProvider) = this.copy(dynamoCredentialsProviderOpt = Some(dynamoCredentialsProvider))
+
+  def withDynamoRoleIamArn(dynamoRoleIamArn: String) = this.copy(dynamoCredentialsProviderOpt = Some(new STSAssumeRoleSessionCredentialsProvider(dynamoRoleIamArn, clientAppName)))
+
+  def withMetricsConfig(metricsConfiguration: MetricsConfiguration) = this.copy(metricsConfigOpt = Some(metricsConfiguration))
+
+  def toBridgeConfiguration =
+    BridgeConfiguration(
+      clientAppName,
+      streamName,
+      bucketName,
+      kinesisCredentialsProviderOpt.getOrElse(new DefaultAWSCredentialsProviderChain),
+      dynamoCredentialsProviderOpt.getOrElse(new DefaultAWSCredentialsProviderChain),
+      metricsConfigOpt
+    )
+}
+
+object BridgeConfigurationBuilder {
+
+  def aBridgeConfiguration(clientAppName: String, streamName: String, bucketName: String) =
+    BridgeConfigurationBuilder(clientAppName, streamName, bucketName)
+
+}
+
 
 /**
  * If provided, this configuration enables KCL sending its own metrics to CloudWatch

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.9-SNAPSHOT"
+version in ThisBuild := "0.1.0-SNAPSHOT"


### PR DESCRIPTION
The `BridgeConfiguration` only accepts *iamRoleArn*s as configuration parameters to connect to kinesis.
Unfortunately in my service I have to *assume* an intermediate role before being able to *assume* the role that has grants to connect to **Kinesis**.

It's my understanding that this library provides a facade to AWS and tries to hide it as much as possible, but in this case, client code *needs* to be AWS aware.
For this reason I've modified the `BridgeConfiguration` and reaplced the optional *iamRoleArn* with mandatory `AWSCrendentials` fields.
I've also made `BridgeConfiguration` private and created a `BridgeConfigurationBuilder` that hides some boilerplate to client code that can be AWS unaware, but also offer `withXX` methods to customise the configuration. 